### PR TITLE
Container and init.sh script update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,26 @@
-FROM ubuntu:14.04
-
-# Set the reset cache variable
-ENV REFRESHED_AT 2015-07-30
+FROM ubuntu:18.04
 
 # Update the repositories list and install software to add a PPA
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
-
-# Add the PPA with ffmpeg
-    apt-add-repository -y ppa:mc3man/trusty-media && \
-    apt-get update && \
-
-# Install required software
     apt-get install -y git \
-                       mercurial \
-                       xvfb \
-                       xfonts-base \
-                       xfonts-75dpi \
-                       xfonts-100dpi \
-                       xfonts-cyrillic \
-                       gource \
-                       screen \
-                       ffmpeg
+        mercurial \
+        xvfb \
+        xfonts-base \
+        xfonts-75dpi \
+        xfonts-100dpi \
+        xfonts-cyrillic \
+        gource \
+        screen \
+        ffmpeg && \
+    apt-get -yq autoremove && \
+    apt-get -yq clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/*
 
 # Add the init script
-ADD ./init.sh /tmp/init.sh
-
-# Set the default title
-ENV TITLE "Example title"
+COPY init.sh /usr/local/bin/init.sh
 
 # Mount volumes
 VOLUME ["/repoRoot", "/avatars", "/results"]
@@ -37,4 +30,4 @@ WORKDIR /repoRoot
 
 # Run the init script by default
 CMD [""]
-ENTRYPOINT ["/tmp/init.sh"]
+ENTRYPOINT ["bash", "/usr/local/bin/init.sh"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [Docker](https://www.docker.com) container that has the capability to generate [Gource](https://code.google.com/p/gource) videos in a headless environment.
 
 ## Customizable Environment Variables
+
 Let me know if you would like more to be customizeable.
 
 + RES (default: 1920x1080)
@@ -11,11 +12,11 @@ Let me know if you would like more to be customizeable.
 
 ## Base Docker Image
 
-- [ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/)
++ [ubuntu:14.04](https://registry.hub.docker.com/_/ubuntu/)
 
-## Requirements:
+## Requirements
 
-- [Docker](http://www.docker.com/)
++ [Docker](http://www.docker.com/)
 
 ## Usage
 
@@ -23,29 +24,52 @@ Let me know if you would like more to be customizeable.
 
 Download [automated build](https://registry.hub.docker.com/u/twelvenights/gource/) from public [Docker Hub Registry](https://registry.hub.docker.com/):
 
-    docker pull twelvenights/gource
+```sh
+docker pull twelvenights/gource
+```
 
 Alternatively, you can build an image from the `Dockerfile`:
 
-    git clone git@github.com:twelvenights/docker-gource.git
-    cd docker-gource
-    docker build -t twelvenights/gource .
+```sh
+git clone git@github.com:twelvenights/docker-gource.git
+cd docker-gource
+docker build -t twelvenights/gource .
+```
 
 ### Running
 
-    docker run --rm --name gource \
-               -v REPO_ROOT:/repoRoot \
-               -v RESULTS_FOLDER:/results \
-               -v AVATARS_FOLDER:/avatars \
-               --env TITLE="My overridden title text" \
-               twelvenights/gource
+```sh
+docker run --rm --name gource \
+    -v REPO_ROOT:/repoRoot \
+    -v RESULTS_FOLDER:/results \
+    -v AVATARS_FOLDER:/avatars \
+    --env TITLE="My overridden title text" \
+    twelvenights/gource
+```
+
+### Override options
+
+There are several options you can override using environment variables passed to the container:
+
++ DEPTH: The color depth to use as an option to `screen`. (default: 24)
++ EXTRA_OPTS: Any extra options to *gource* you wish to add.
++ FONT_COLOR: Font colour used by the date and title in hex (`--font-colour`). (default: FFFF00)
++ FONT_SIZE: Font size used by the date and title (`--font-size`). (default: 25)
++ FPS: Framerate of output (25,30,60), used by both gource (`-r`) and ffmpeg (`-r`). (default: 30)
++ HIDE: Hide one or more display elements (`--hide`).  (default: dirnames,filenames)
++ RES: Set the viewport size. (default: 1920x1080)
++ SEC_PER_DAY: Speed of simulation in seconds per day (`--seconds-per-day`). (default: 1)
++ TITLE: Set a title (`--title`). (default: Example title)
++ USER_SCALE: Change scale of user avatars (`--user-scale`). (default: 4.0)
 
 If you want repository usernames to be replaced with images then put images to avatars folder.
 Name for the avatar image must match the username (e.g taivokasper.png).
 
 ### Example: Automatically download Github repository
 
-    docker run --rm --name gource \
-               -v $HOME/Videos/gource:/results \
-               --env TITLE="Docker Evolution" \
-               twelvenights/gource docker/docker
+```sh
+docker run --rm --name gource \
+    -v $HOME/Videos/gource:/results \
+    --env TITLE="Docker Evolution" \
+    twelvenights/gource docker/docker
+```

--- a/init.sh
+++ b/init.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-# Stop on first error
-set -e
-
 # Remove previous results
 rm -f /results/{gource.ppm,gource.mp4}
 
 # Define defaults
-RES="${RES:-1920x1080}"
 DEPTH="${DEPTH:-24}"
+FONT_COLOR="${FONT_COLOR:-FFFF00}"
+FONT_SIZE="${FONT_SIZE:-25}"
+FPS="${FPS:-30}"
+HIDE="${HIDE:-dirnames,filenames}"
+RES="${RES:-1920x1080}"
+SEC_PER_DAY="${SEC_PER_DAY:-1}"
+TITLE="${TITLE:-Example title}"
+USER_SCALE="${USER_SCALE:-4.0}"
 
 github_user=''
 github_repository=''
@@ -17,24 +21,22 @@ github_repository=''
 prepare_github_repository () {
   repository_string=$1
 
-  IFS='/' read -ra repository_split <<< "$repository_string"
+  counter=$( awk -F'/' '{print NF-1}' <<< "$repository_string" )
+  _=$(( counter + 0 ))
 
-  counter=2
-  for i in "${repository_split[@]}"; do
-    ((counter--))
-  done
-
-  if [ "${counter}" -eq "0" ]; then
-    github_user=${repository_split[0]}
-    github_repository=${repository_split[1]}
+   # shellcheck disable=SC2086
+  if [ $counter -eq 1 ]; then
+    IFS='/' read -ra repository_split <<< "$repository_string"
+    github_user="${repository_split[0]}"
+    github_repository="${repository_split[1]}"
   else
-    echo ERROR: Failed to parse the Github repository string
+    echo 'ERROR: Failed to parse the Github repository string'
     # Terminate and indicate error
     exit 1
   fi
 
   # Download git repository
-  git clone "https://github.com/$repository_string.git" .
+  git clone "https://github.com/${repository_string}.git" .
 }
 
 render () {
@@ -42,50 +44,52 @@ render () {
     recording \
     xvfb-run -a -s "-screen 0 ${RES}x${DEPTH}" \
     gource "-$RES" \
-      -r 30 \
+      -r "$FPS" \
       --title "$TITLE" \
       --user-image-dir /avatars/ \
       --highlight-all-users \
-      -s 0.5 \
-      --seconds-per-day .4 \
-      --hide dirnames,filenames \
-      --font-size 25 \
-      --font-colour FFFF00 \
-      --user-scale 4.0 \
-      --auto-skip-seconds 1 \
+      --seconds-per-day "$SEC_PER_DAY" \
+      --hide "$HIDE" \
+      --font-size "$FONT_SIZE" \
+      --font-colour "$FONT_COLOR" \
+      --user-scale "$USER_SCALE" \
+      --auto-skip-seconds 1 $EXTRA_OPTS \
       -o /results/gource.ppm
 
   # This hack is needed because gource process doesn't stop
   lastsize="0"
   filesize="0"
 
-  while [[ "$filesize" -eq "0" || $lastsize -lt $filesize ]] ;
-  do
+  while [[ "$filesize" -eq "0" || $lastsize -lt $filesize ]]; do
       sleep 20
       lastsize="$filesize"
       filesize=$(stat -c '%s' /results/gource.ppm)
-      echo 'Polling the size. Current size is' $filesize
+      echo "Polling the size. Current size is ${filesize}"
   done
 
   echo 'Force stopping recording because file size is not growing'
   screen -S recording -X quit
 
-  xvfb-run -a -s "-screen 0 ${RES}x${DEPTH}" ffmpeg -y -r 30 -f image2pipe -loglevel info -vcodec ppm -i /results/gource.ppm -vcodec libx264 -preset ultrafast -pix_fmt yuv420p -crf 1 -threads 0 -bf 0 /results/gource.mp4
+  xvfb-run -a -s "-screen 0 ${RES}x${DEPTH}" ffmpeg -y -r "$FPS" -f image2pipe \
+    -loglevel info -vcodec ppm -i /results/gource.ppm -vcodec libx264 \
+    -preset ultrafast -pix_fmt yuv420p -crf 1 -threads 0 -bf 0 /results/gource.mp4
+
+  # Remove the intermediate PPM file
   rm -f /results/gource.ppm
 }
 
 # Check if any arguments were passed or if the passed argument is empty
-if [ $# -eq 0 -o -z "$1" ]; then
+if [ $# -eq 0 ] || [ -z "$1" ]; then
   echo "No arguments supplied. Expecting a volume mounted with the repository."
 
   # Start the rendering process
   render
 else
   # Parse the Github repository string and download the repository
-  prepare_github_repository $1
+  prepare_github_repository "$1"
 
   # Start the rendering process
   render
 
-  mv /results/gource.mp4 "/results/$github_user-$github_repository.mp4"
+  mv /results/gource.mp4 "/results/${github_user}-${github_repository}.mp4"
 fi


### PR DESCRIPTION
* Update to ubuntu:18.04
* Clean up apt at the end of the RUN step
* ubuntu:18.04 no longer needs a custom repo to get gource
* Removed ENV setting for TITLE.  Added as a default in `init.sh`
* Move `init.sh` to `/usr/local/bin` in the container
* Change the entrypoint to use bash to call `init.sh` as that seemed to fix an issue with screen not running correctly
* Add many configurable options through environment variables in `init.sh`
* Stop `set -e` in `init.sh`.  Non-fatal commands were failing, which would cause premature termination
* Rework the `prepare_github_repository` function
* Ran `init.sh` through shellcheck and fixed all linting errors